### PR TITLE
Fix various search issues.

### DIFF
--- a/lib/HiveWeb/Controller/API/Admin/Members.pm
+++ b/lib/HiveWeb/Controller/API/Admin/Members.pm
@@ -457,6 +457,7 @@ sub index :Path :Args(0)
 	)->get_column('last_access_time')->as_query();
 	$$last_query->[0] .= ' AS last_access_time';
 
+	# Cannot prefetch 'member_mgroups' as it conflicts with the 'AS X' hack on the subqueries.
 	my $member_attrs =
 		{
 		'+select' => [ $count_query, $last_query, $sum_query ],


### PR DESCRIPTION
- A blank search string caused a 500.
- If the page specified is out of bounds, it now goes to the last page.
- The prefetch was removed because it can't be combined with sorting by subquery columns.