### PR TITLE
Search other fields

### DIFF
--- a/lib/HiveWeb/Controller/API/Admin/Members.pm
+++ b/lib/HiveWeb/Controller/API/Admin/Members.pm
@@ -623,14 +623,51 @@ sub index :Path :Args(0)
 
 		foreach my $name (@names)
 			{
-			push (@$names,
+			if ($name =~ s/^email://i)
 				{
-				-or =>
+				push(@$names, { email => { ilike => '%' . $name . '%' } });
+				}
+			elsif ($name =~ s/^handle://i)
+				{
+				push(@$names, { handle => { ilike => '%' . $name . '%' } });
+				}
+			elsif ($name =~ s/^paypal://i)
+				{
+				push(@$names, { paypal_email => { ilike => '%' . $name . '%' } });
+				}
+			elsif ($name =~ s/^fname://i)
+				{
+				push(@$names, { fname => { ilike => '%' . $name . '%' } });
+				}
+			elsif ($name =~ s/^lname://i)
+				{
+				push(@$names, { lname => { ilike => '%' . $name . '%' } });
+				}
+			elsif ($name =~ s/^name://i)
+				{
+				push(@$names,
 					{
-					fname => { ilike => '%' . $name . '%' },
-					lname => { ilike => '%' . $name . '%' },
-					}
-				});
+					-or =>
+						{
+						fname => { ilike => '%' . $name . '%' },
+						lname => { ilike => '%' . $name . '%' },
+						}
+					});
+				}
+			else
+				{
+				push (@$names,
+					{
+					-or =>
+						{
+						fname        => { ilike => '%' . $name . '%' },
+						lname        => { ilike => '%' . $name . '%' },
+						handle       => { ilike => '%' . $name . '%' },
+						email        => { ilike => '%' . $name . '%' },
+						paypal_email => { ilike => '%' . $name . '%' },
+						}
+					});
+				}
 			}
 		}
 

--- a/root/src/admin/members.tt
+++ b/root/src/admin/members.tt
@@ -19,7 +19,7 @@ nav ul.pagination
 		</div>
 		<div class="panel-body">
 			<div class="search" style="float: right; width: 25%; min-width: 100px;">
-				<input type="text" class="form-control" placeholder="Search for members" />
+				<input type="text" class="form-control" placeholder="Search for members" title="<span class='label label-info'>fname:</span>, <span class='label label-info'>lname:</span>, <span class='label label-info'>name:</span>, <span class='label label-info'>email:</span>, and <span class='label label-info'>paypal:</span> may be prepended to a search term only search that column.  Note that <span class='label label-info'>name:</span> searches both first and last name." data-placement="top" data-toggle="tooltip" />
 			</div>
 			<nav id="pagination_top" class="hive-member-pagination">
 			</nav>
@@ -659,6 +659,11 @@ $(function()
 		});
 
 	load_members();
+	$('[data-toggle="tooltip"]').tooltip(
+		{
+		html:    true,
+		trigger: "focus"
+		});
 	});
 
 var key_timer = null;


### PR DESCRIPTION
Now, by default, it searches first name, last name, handle, email, and PayPal email fields for each search string.  You can prepend name:, fname:, lname:, handle:, email:, or paypal: to a term to limit it to only search that field.  name: searches both first and last name (how it worked before this update.