### PR TITLE
API version 2

### DIFF
--- a/lib/HiveWeb/Controller/API.pm
+++ b/lib/HiveWeb/Controller/API.pm
@@ -131,14 +131,23 @@ sub access :Local
 	my $out     = $c->stash()->{out};
 	my $device  = $c->model('DB::Device')->find({ name => $in->{device} });
 	my $data    = $in->{data};
-	my $version = $in->{version} || 1;
+	my $version = int($in->{version} || 1);
 	my $view    = $c->view('ChecksummedJSON');
 
 	if (!defined($device))
 		{
-		$out->{response} = JSON->false();
-		$out->{error} = 'Cannot find device.';
+		$out->{response} = \0;
+		$out->{error}    = 'Cannot find device.';
 		$c->response()->status(400)
+			if ($data->{http});
+		return;
+		}
+
+	if ($device->min_version() > $version || $version > $device->max_version())
+		{
+		$out->{response} = \0;
+		$out->{error}    = 'Invalid version for device.';
+		$c->response()->status(403)
 			if ($data->{http});
 		return;
 		}

--- a/lib/HiveWeb/Schema/Result/Device.pm
+++ b/lib/HiveWeb/Schema/Result/Device.pm
@@ -9,35 +9,41 @@ use MooseX::NonMoose;
 use MooseX::MarkAsMethods autoclean => 1;
 extends 'DBIx::Class::Core';
 
-__PACKAGE__->load_components("InflateColumn::DateTime");
+__PACKAGE__->load_components('InflateColumn::DateTime');
 
-__PACKAGE__->table("device");
+__PACKAGE__->table('device');
 
 __PACKAGE__->add_columns(
-  "device_id",
-  { data_type => "uuid", is_nullable => 0, size => 16 },
-  "key",
-  { data_type => "bytea", is_nullable => 0 },
-  "name",
-  { data_type => "varchar", is_nullable => 0, size => 64 },
-);
+  'device_id',
+  { data_type => 'uuid', is_nullable => 0, size => 16 },
+  'key',
+  { data_type => 'bytea', is_nullable => 0 },
+  'name',
+  { data_type => 'varchar', is_nullable => 0, size => 64 },
+  'nonce',
+  { data_type => 'bytea', is_nullable => 1 },
+	'min_version',
+	{ data_type => 'integer', is_nullable => 0, default_value => '1', },
+	'max_version',
+	{ data_type => 'integer', is_nullable => 0, default_value => '1', },
+	);
 
-__PACKAGE__->set_primary_key("device_id");
+__PACKAGE__->set_primary_key('device_id');
 
 __PACKAGE__->has_many(
-  "device_items",
-  "HiveWeb::Schema::Result::DeviceItem",
-  { "foreign.device_id" => "self.device_id" },
-  { cascade_copy => 0, cascade_delete => 0 },
-);
+								'device_items',
+								'HiveWeb::Schema::Result::DeviceItem',
+								{ 'foreign.device_id' => 'self.device_id' },
+								{ cascade_copy => 0, cascade_delete => 0 },
+								);
 
 __PACKAGE__->has_many(
-  "vend_logs",
-  "HiveWeb::Schema::Result::VendLog",
-  { "foreign.device_id" => "self.device_id" },
-  { cascade_copy => 0, cascade_delete => 0 },
-);
+								'vend_logs',
+								'HiveWeb::Schema::Result::VendLog',
+								{ 'foreign.device_id' => 'self.device_id' },
+								{ cascade_copy => 0, cascade_delete => 0 },
+								);
 
-__PACKAGE__->many_to_many("items", "device_items", "item");
+__PACKAGE__->many_to_many('items', 'device_items', 'item');
 __PACKAGE__->meta->make_immutable;
 1;


### PR DESCRIPTION
Adds in the following features:

- Version fields in database to peg devices to range of versions
- V2 requires the device to include the correct nonce inside of its checksummed structure.  This stops replay attacks.
- Added a get_nonce operation to fetch the expected nonce from the server.