### PR TITLE
Fix various payment Issues

### DIFF
--- a/bin/expire_memberships.pl
+++ b/bin/expire_memberships.pl
@@ -75,7 +75,7 @@ while (my $candidate = $candidates->next())
 		$schema->txn_do(sub
 			{
 			my $lpc = $candidate->linked_members();
-			if ($expire && $days > 8)
+			if ($expire && $days > 31)
 				{
 				printf("Looking at %s %s: %i\n", $candidate->fname(), $candidate->lname(), $days);
 				$candidate->remove_group($pe_group_id, undef, 'end of subscription');

--- a/lib/HiveWeb/Schema/Result/IPNMessage.pm
+++ b/lib/HiveWeb/Schema/Result/IPNMessage.pm
@@ -103,6 +103,12 @@ sub subscr_payment
 		{
 		$member->remove_group(\'pending_payments', undef, 'initial payment');
 		$member->add_group(\'members', undef, 'initial payment');
+		my $lpc = $member->linked_members();
+		while (my $link = $lpc->next())
+			{
+			$link->remove_group(\'pending_payments', undef, 'initial payment');
+			$link->remove_group(\'members', undef, 'initial payment');
+			}
 
 		my $application = $member->find_related('applications',
 			{

--- a/lib/HiveWeb/Schema/Result/Member.pm
+++ b/lib/HiveWeb/Schema/Result/Member.pm
@@ -234,7 +234,7 @@ sub update
 	my $attrs = shift;
 	my %dirty = $self->get_dirty_columns();
 
-	if ($dirty{paypal_email} )
+	if ($dirty{paypal_email})
 		{
 		$self->result_source()->schema()->resultset('Action')->create(
 			{

--- a/lib/HiveWeb/Schema/Result/Member.pm
+++ b/lib/HiveWeb/Schema/Result/Member.pm
@@ -234,11 +234,11 @@ sub update
 	my $attrs = shift;
 	my %dirty = $self->get_dirty_columns();
 
-	if ($dirty{paypal_email} && $self->paypal_email =~ /.@./)
+	if ($dirty{paypal_email} )
 		{
 		$self->result_source()->schema()->resultset('Action')->create(
 			{
-			queuing_member_id => $self->member_id(),
+			queuing_member_id => $HiveWeb::Schema::member_id // $self->member_id(),
 			action_type       => 'paypal.refresh',
 			row_id            => $self->member_id(),
 			});

--- a/root/static/js/pages/admin_members.js
+++ b/root/static/js/pages/admin_members.js
@@ -793,6 +793,7 @@ function edit(member_id)
 				$("div#pay_div").css("display", "none");
 				$("div#link_div").css("display", "");
 				$("div#link_div div").html("This account is linked to " + data.link.fname + " " + data.link.lname + ". Please visit that acconut to edit payment and link info.");
+				link.set([]);
 				}
 			else
 				{


### PR DESCRIPTION
- Correct expire user script to cancel after 31 days.
- Grant membership to linked accounts on initial payment
- Refresh PayPal whenever `paypal_email` changes at all
- Fix user edit for linked members