### PR TITLE
Better PayPal Messages

### DIFF
--- a/hiveweb.pl
+++ b/hiveweb.pl
@@ -96,7 +96,17 @@
 				subject  => 'Welcome to Hive13',
 				},
 			confirm_cancel => { subject => 'Hive13 Subscription Cancelled' },
-			notify_cancel  => { subject => 'Member Subscription Cancelled' },
+			alert_failed   => { subject => 'Hive13 Subscription Payment Failed' },
+			notify_cancel  =>
+				{
+				subject => 'Member Subscription Cancelled',
+				to      => 'intwebsandbox@hive13.org',
+				},
+			notify_failed  =>
+				{
+				subject => 'Member Payment Failed',
+				to      => 'intwebsandbox@hive13.org',
+				},
 			password_reset =>
 				{
 				priority => 1,
@@ -106,11 +116,6 @@
 				{
 				subject  => 'Your Hive13 Subscription is past due',
 				priority => 40,
-				},
-			past_due =>
-				{
-				temp_plain => 'email/member/past_due_plain.tt',
-				subject    => 'Your Hive13 Subscription is past due',
 				},
 			},
 		notify =>

--- a/lib/HiveWeb/Schema/Result/IPNMessage.pm
+++ b/lib/HiveWeb/Schema/Result/IPNMessage.pm
@@ -153,6 +153,27 @@ sub subscr_payment
 		}
 	}
 
+sub subscr_failed
+	{
+	my ($self) = @_;
+
+	my $schema = $self->result_source()->schema();
+
+	$schema->resultset('Action')->create(
+		{
+		queuing_member_id => $self->member_id(),
+		action_type       => 'member.alert_failed',
+		row_id            => $self->member_id(),
+		}) || die 'Could not queue notification: ' . $!;
+
+	$schema->resultset('Action')->create(
+		{
+		queuing_member_id => $self->member_id(),
+		action_type       => 'member.notify_failed',
+		row_id            => $self->member_id(),
+		}) || die 'Could not queue notification: ' . $!;
+	}
+
 sub subscr_cancel
 	{
 	my ($self) = @_;
@@ -220,6 +241,10 @@ sub process
 			{
 			$self->subscr_payment($member, $parameters);
 			}
+		elsif ($type eq 'subscr_failed')
+			{
+			$self->subscr_failed();
+			}
 		elsif ($type eq 'subscr_cancel')
 			{
 			$self->subscr_cancel();
@@ -233,7 +258,7 @@ sub process
 			$schema->resultset('Log')->new_log(
 				{
 				type    => 'ipn.unknown_type',
-				message => 'Unknown payment type in message ' . $self->ipn_message_id()
+				message => "Unknown payment type $type in message $self->ipn_message_id"
 				});
 			}
 		}

--- a/root/src/email/member/alert_failed_plain.tt
+++ b/root/src/email/member/alert_failed_plain.tt
@@ -1,0 +1,10 @@
+Hello [% member.fname %],
+
+We've noticed your PayPal subscription has failed.
+
+Please login to PayPal to view and correct any notifications such as an expired credit card.  If you need to re-subscribe, just visit [% base_url _ 'member/pay' %] and you'll see the subscribe button.  If you have any questions, contact our Treasurer at treasurer@hive13.org.
+
+Thank you,
+intweb
+
+[%~# vim:set filetype=tt2: ~%]

--- a/root/src/email/member/notify_failed_plain.tt
+++ b/root/src/email/member/notify_failed_plain.tt
@@ -1,0 +1,8 @@
+Hello Leadership,
+
+[% member.fname %] [% member.lname %]'s PayPal payment has failed.  I've sent out an alert to [% member.fname %] about it.
+
+Sincerely,
+intweb
+
+[%~# vim:set filetype=tt2: ~%]


### PR DESCRIPTION
Split out cancelled vs. failed payment and send better-worded messages in each case.