### PR TITLE
Update email templates 1

### DIFF
--- a/root/src/email/member/confirm_cancel_plain.tt
+++ b/root/src/email/member/confirm_cancel_plain.tt
@@ -2,7 +2,9 @@ Hello [% member.fname %],
 
 We've noticed your PayPal subscription has been cancelled.  If this is intentional, please visit [% base_url _ 'member/cancel' %] to confirm.
 
-If you're canceling your subscription to change membership level, simply visit [% base_url _ 'member/pay' %] to get that set up. We thank you for your continued contribution to our space.
+If you're in the process of changing membership level, you have now successfully canceled your old subscription.
+
+Next, visit [% base_url _ 'member/pay' %] to get your new membership level set up. We thank you for your continued contribution to our space.
 
 If this is not intentional, please login to PayPal to view and correct any notifications such as an expired credit card.  If you need to re-subscribe, just visit [% base_url _ 'member/pay' %] and you'll see the subscribe button.  If you have any questions, contact our Treasurer at treasurer@hive13.org.
 

--- a/root/src/email/member/confirm_cancel_plain.tt
+++ b/root/src/email/member/confirm_cancel_plain.tt
@@ -2,6 +2,8 @@ Hello [% member.fname %],
 
 We've noticed your PayPal subscription has been cancelled.  If this is intentional, please visit [% base_url _ 'member/cancel' %] to confirm.
 
+If you're canceling your subscription to upgrade to Cornerstone Membership, you can disregard this message and we thank you for your contribution.
+
 If this is not intentional, please login to PayPal to view and correct any notifications such as an expired credit card.  If you need to re-subscribe, just visit [% base_url _ 'member/pay' %] and you'll see the subscribe button.  If you have any questions, contact our Treasurer at treasurer@hive13.org.
 
 Thank you,

--- a/root/src/email/member/confirm_cancel_plain.tt
+++ b/root/src/email/member/confirm_cancel_plain.tt
@@ -2,7 +2,7 @@ Hello [% member.fname %],
 
 We've noticed your PayPal subscription has been cancelled.  If this is intentional, please visit [% base_url _ 'member/cancel' %] to confirm.
 
-If you're canceling your subscription to upgrade to Cornerstone Membership, you can disregard this message and we thank you for your contribution.
+If you're canceling your subscription to upgrade to Cornerstone Membership, you can disregard this message and we thank you for your contribution. Simply visit [% base_url _ 'member/pay' %] to get that set up.
 
 If this is not intentional, please login to PayPal to view and correct any notifications such as an expired credit card.  If you need to re-subscribe, just visit [% base_url _ 'member/pay' %] and you'll see the subscribe button.  If you have any questions, contact our Treasurer at treasurer@hive13.org.
 

--- a/root/src/email/member/confirm_cancel_plain.tt
+++ b/root/src/email/member/confirm_cancel_plain.tt
@@ -2,7 +2,7 @@ Hello [% member.fname %],
 
 We've noticed your PayPal subscription has been cancelled.  If this is intentional, please visit [% base_url _ 'member/cancel' %] to confirm.
 
-If you're canceling your subscription to upgrade to Cornerstone Membership, you can disregard this message and we thank you for your contribution. Simply visit [% base_url _ 'member/pay' %] to get that set up.
+If you're canceling your subscription to upgrade to Cornerstone Membership, simply visit [% base_url _ 'member/pay' %] to get that set up. We thank you for your contribution.
 
 If this is not intentional, please login to PayPal to view and correct any notifications such as an expired credit card.  If you need to re-subscribe, just visit [% base_url _ 'member/pay' %] and you'll see the subscribe button.  If you have any questions, contact our Treasurer at treasurer@hive13.org.
 

--- a/root/src/email/member/confirm_cancel_plain.tt
+++ b/root/src/email/member/confirm_cancel_plain.tt
@@ -2,7 +2,7 @@ Hello [% member.fname %],
 
 We've noticed your PayPal subscription has been cancelled.  If this is intentional, please visit [% base_url _ 'member/cancel' %] to confirm.
 
-If you're canceling your subscription to upgrade to Cornerstone Membership, simply visit [% base_url _ 'member/pay' %] to get that set up. We thank you for your contribution.
+If you're canceling your subscription to change membership level, simply visit [% base_url _ 'member/pay' %] to get that set up. We thank you for your continued contribution to our space.
 
 If this is not intentional, please login to PayPal to view and correct any notifications such as an expired credit card.  If you need to re-subscribe, just visit [% base_url _ 'member/pay' %] and you'll see the subscribe button.  If you have any questions, contact our Treasurer at treasurer@hive13.org.
 


### PR DESCRIPTION
Here’s a draft of a change to the email template for a cancelled PayPal subscription that says this message is an expected part of upgrading to Cornerstone membership. 